### PR TITLE
Fix noteコラボ出演のリンクを修正

### DIFF
--- a/docs/words/ゆる言語学ラジオ.rst
+++ b/docs/words/ゆる言語学ラジオ.rst
@@ -386,7 +386,7 @@
 * 2022年05月15日 サポータコミュニティ2000名を突破
 * 2022年04月20日 Voicy総再生回数1万回突破！
 * 2022年04月08日 `朝日新聞コラボ出演 <https://open.spotify.com/episode/4TwQ4R3PHXbTY6HAcPgcBm?si=F8TJxQ9oSBOu_Fjm04gDqA>`_ 
-* 2022年03月31日 `noteコラボ出演 <https://store.line.me/stickershop/product/18955892/ja>`_ 
+* 2022年03月31日 `noteコラボ出演 <https://www.youtube.com/live/goYHBS4Fa8k?si=xxES-At-j0jcy_6->`_ 
 * 2022年03月31日 `Lineスタンプ公開 <https://store.line.me/stickershop/product/18955892/ja>`_ 
 * 2022年03月17日 :doc:`JAPAN_PODCAST_AWARDS` （ベストナレッジ賞、リスナーズチョイス1位）
 * 2022年03月12日 Podcast weekend 出店


### PR DESCRIPTION
## 変更点
「ヒストリー」の「2022年03月31日 noteコラボ出演」のリンク先が「2022年03月31日 LINEスタンプ公開」のものとなっていたので以下URLに変更しました。

https://www.youtube.com/live/goYHBS4Fa8k?si=xxES-At-j0jcy_6-

## 備考
いつもありがとうございます。自分はサポーターコミュニティーには所属していないのですが、ゆる言語学ラジオが好きで、この用語集もよく利用させていただいております。初めてのコントリビュートなので、慣れない点があるかもしれませんが、ご確認のほどお願いします。